### PR TITLE
Updated usage of deprecated  base64.decodestring() to bas64.decodebytes()

### DIFF
--- a/django_bouncy/utils.py
+++ b/django_bouncy/utils.py
@@ -99,7 +99,7 @@ def verify_notification(data):
     """
     pemfile = grab_keyfile(data['SigningCertURL'])
     cert = crypto.load_certificate(crypto.FILETYPE_PEM, pemfile)
-    signature = base64.decodestring(six.b(data['Signature']))
+    signature = base64.decodebytes(six.b(data['Signature']))
 
     if data['Type'] == "Notification":
         hash_format = NOTIFICATION_HASH_FORMAT


### PR DESCRIPTION
`decodestring` was being [deprecated](https://docs.python.org/3.8/library/base64.html#base64.decodestring) since python version 3.1. and is removed in 3.9.6 which means current release will trigger the following error `module 'base64' has no attribute 'decodestring'`


